### PR TITLE
Don't use local grunt-phantomcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-phantomcss": "file:../../../../var/folders/78/rzwk_29n47g0dc0rypjgl5n80000gn/T/npm-2669-613b93dd/git-cache-b7d5cd4d2197/2112d7456d2c0d33e414a5597de003ea2bc7bc2c",
+    "grunt-phantomcss": "git://github.com/anselmh/grunt-phantomcss.git",
     "grunt-sass": "^0.18.0",
-    "phantomjs": "^1.9.7-14",
     "time-grunt": "^1.0.0"
   }
 }


### PR DESCRIPTION
and remove phantomjs dependency for now to prevent `npm ERR! peerinvalid The package phantomjs does not satisfy its siblings' peerDependencies requirements!` and let the packages itself handle this.